### PR TITLE
Fix errors in onboarding API

### DIFF
--- a/netbox_onboarding/onboard.py
+++ b/netbox_onboarding/onboard.py
@@ -139,11 +139,9 @@ class NetdevKeeper(object):
         logging.info(f"COLLECT: device information {mgmt_ipaddr}")
 
         try:
-            platform = self.ot.platform.slug
-            if platform == "nxos":
-                platform = "nxos_ssh"
+            driver_name = self.ot.platform.napalm_driver
 
-            driver = get_network_driver(platform)
+            driver = get_network_driver(driver_name)
             dev = driver(hostname=mgmt_ipaddr, username=self.username, password=self.password, timeout=self.ot.timeout)
 
             dev.open()


### PR DESCRIPTION
- Add missing `get_queue` import
- Remove `sort_by_digits` and `OnboardDeviceSerializer` as dead code
- `platform` is a mandatory parameter (we need it to look up the NAPALM driver)
- `platform` looks up by `slug`, not by `name`
- To look up the NAPALM driver, use the Platform `napalm_driver` field, not the `name`.