### PR TITLE
Enable Django debug toolbar unconditionally in development Dockerfile

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -17,6 +17,12 @@ RUN git clone --single-branch --branch ${netbox_ver} https://github.com/netbox-c
     cd /opt/netbox/ && \
     pip install -r /opt/netbox/requirements.txt
 
+# Make the django-debug-toolbar always visible when DEBUG is enabled,
+# except when we're running Django unit-tests.
+RUN echo "import sys" >> /opt/netbox/netbox/netbox/settings.py && \
+    echo "TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'" >> /opt/netbox/netbox/netbox/settings.py && \
+    echo "DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': lambda _: DEBUG and not TESTING }" >> /opt/netbox/netbox/netbox/settings.py
+
 # Work around https://github.com/rq/django-rq/issues/421
 RUN pip install django-rq==2.3.2
 


### PR DESCRIPTION
Normally, when `DEBUG = True` in the Django settings, netbox presents the `django-debug-toolbar` on requests whose source matches `INTERNAL_IPS` (by default, only 127.0.0.1 and ::1). When running in docker-compose, requests do not appear to be coming from localhost, but instead from the Docker bridge IP, which may vary. 

Since this is explicitly a development environment for the plugin, not a production deployment, the easiest way to work around this is to use django-debug-toolbar's own method of overriding the logic that checks INTERNAL_IPS, and simply have it present the toolbar on a request from *any* source so long as `DEBUG = True`.

We have to provide this by patching netbox's `settings.py`, rather than in our standalone `configuration.py`, because `settings.py` explicitly only imports specific variables from `configuration.py` and this is not one of them.