### PR TITLE
Fix for Netbox issue 4910

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -13,8 +13,11 @@ RUN pip install --upgrade pip\
 # -------------------------------------------------------------------------------------
 # Install NetBox
 # -------------------------------------------------------------------------------------
+# Remove redis==3.4.1 from the requirements.txt file as a workaround to #4910
+# https://github.com/netbox-community/netbox/issues/4910, required for version 2.8.8 and earlier
 RUN git clone --single-branch --branch ${netbox_ver} https://github.com/netbox-community/netbox.git /opt/netbox/ && \
     cd /opt/netbox/ && \
+    sed -i '/^redis\=\=/d' /opt/netbox/requirements.txt && \
     pip install -r /opt/netbox/requirements.txt
 
 # Make the django-debug-toolbar always visible when DEBUG is enabled,

--- a/netbox_onboarding/onboard.py
+++ b/netbox_onboarding/onboard.py
@@ -562,7 +562,6 @@ class NetboxKeeper:
 
     def ensure_device(self):
         """Ensure that the device represented by the DevNetKeeper exists in the NetBox system."""
-
         # Only check the device role and device type if the device do not exist already
         if not self.check_if_device_already_exist():
             self.ensure_device_type()


### PR DESCRIPTION
Implement the workaround recommended in [ISSUE4910](https://github.com/netbox-community/netbox/issues/4910) by removing `redis==3.4.1` from the requirements.txt