### PR TITLE
Improve search for existing objects

### DIFF
--- a/netbox_onboarding/onboard.py
+++ b/netbox_onboarding/onboard.py
@@ -440,6 +440,21 @@ class NetboxKeeper:
             )
             self.netdev.ot.device_type = self.device_type.slug
             self.netdev.ot.save()
+        except DeviceType.MultipleObjectsReturned:
+            device_types = DeviceType.objects.filter(
+                Q(slug__iexact=slugify(self.netdev.model))
+                | Q(model__iexact=self.netdev.model)
+                | Q(part_number__iexact=self.netdev.model)
+            )
+            device_types_str = ",".join([item.slug for item in device_types])
+            error_message = (
+                f"ERROR, more than one device type found"
+                f"please manually define the device type "
+                f"or update/delete the existing one: {device_types_str}"
+            )
+            raise OnboardException(
+                reason="fail-config", message=error_message,
+            )
         except DeviceType.DoesNotExist:
             if not create_device_type:
                 raise OnboardException(

--- a/netbox_onboarding/onboard.py
+++ b/netbox_onboarding/onboard.py
@@ -13,7 +13,6 @@ limitations under the License.
 """
 
 import logging
-import re
 import socket
 
 from napalm import get_network_driver

--- a/netbox_onboarding/tests/test_netbox_keeper.py
+++ b/netbox_onboarding/tests/test_netbox_keeper.py
@@ -34,6 +34,9 @@ class NetboxKeeperTestCase(TestCase):
         self.platform1 = Platform.objects.create(name="JunOS", slug="junos")
         self.platform2 = Platform.objects.create(name="Cisco NX-OS", slug="cisco-nx-os")
         self.device_type1 = DeviceType.objects.create(slug="srx3600", model="SRX3600", manufacturer=self.manufacturer1)
+        self.device_type2 = DeviceType.objects.create(
+            slug="SRX300", model="SRX 300", part_number="SRX300-SYS-JB", manufacturer=self.manufacturer1
+        )
         self.device_role1 = DeviceRole.objects.create(name="Firewall", slug="firewall")
 
         self.onboarding_task1 = OnboardingTask.objects.create(ip_address="10.10.10.10", site=self.site1)
@@ -94,11 +97,51 @@ class NetboxKeeperTestCase(TestCase):
 
     def test_ensure_device_type_present(self):
         """Verify ensure_device_type function when Manufacturer and DeviceType object are already present."""
+        # Case1: the model is a perfect match for an existing device type
         nbk = NetboxKeeper(self.ndk2)
-
         nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
         self.assertEqual(nbk.manufacturer, self.manufacturer1)
         self.assertEqual(nbk.device_type, self.device_type1)
+
+        # Case2: the model is lower case where the existing devicetype slug is in Uppercase
+        self.ndk3 = NetdevKeeper(self.onboarding_task2)
+        self.ndk3.hostname = "device3"
+        self.ndk3.vendor = "juniper"
+        self.ndk3.model = "srx300"
+        self.ndk3.serial_number = "123456"
+        self.ndk3.mgmt_ifname = "ge-0/0/0"
+        self.ndk3.mgmt_pflen = 24
+
+        nbk = NetboxKeeper(self.ndk3)
+        nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
+        self.assertEqual(nbk.manufacturer, self.manufacturer1)
+        self.assertEqual(nbk.device_type, self.device_type2)
+
+        # Case3: the device model match the model of an existing device_type, not the slug
+        self.ndk4 = NetdevKeeper(self.onboarding_task2)
+        self.ndk4.hostname = "device4"
+        self.ndk4.vendor = "juniper"
+        self.ndk4.model = "srx 300"
+        self.ndk4.serial_number = "123456"
+        self.ndk4.mgmt_ifname = "ge-0/0/0"
+        self.ndk4.mgmt_pflen = 24
+
+        nbk = NetboxKeeper(self.ndk4)
+        nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
+        self.assertEqual(nbk.device_type, self.device_type2)
+
+        # Case4: the device model match the part number of an existing device_type, not the slug
+        self.ndk5 = NetdevKeeper(self.onboarding_task2)
+        self.ndk5.hostname = "device5"
+        self.ndk5.vendor = "juniper"
+        self.ndk5.model = "srx300-sys-jb"
+        self.ndk5.serial_number = "123456"
+        self.ndk5.mgmt_ifname = "ge-0/0/0"
+        self.ndk5.mgmt_pflen = 24
+
+        nbk = NetboxKeeper(self.ndk5)
+        nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
+        self.assertEqual(nbk.device_type, self.device_type2)
 
     def test_ensure_device_role_not_exist(self):
         """Verify ensure_device_role function when DeviceRole do not already exist."""

--- a/netbox_onboarding/tests/test_netbox_keeper.py
+++ b/netbox_onboarding/tests/test_netbox_keeper.py
@@ -75,6 +75,30 @@ class NetboxKeeperTestCase(TestCase):
         self.ndk2.mgmt_ifname = "ge-0/0/0"
         self.ndk2.mgmt_pflen = 24
 
+        self.ndk3 = NetdevKeeper(self.onboarding_task2)
+        self.ndk3.hostname = "device3"
+        self.ndk3.vendor = "juniper"
+        self.ndk3.model = "srx300"
+        self.ndk3.serial_number = "123456"
+        self.ndk3.mgmt_ifname = "ge-0/0/0"
+        self.ndk3.mgmt_pflen = 24
+
+        self.ndk4 = NetdevKeeper(self.onboarding_task2)
+        self.ndk4.hostname = "device4"
+        self.ndk4.vendor = "juniper"
+        self.ndk4.model = "srx 300"
+        self.ndk4.serial_number = "123456"
+        self.ndk4.mgmt_ifname = "ge-0/0/0"
+        self.ndk4.mgmt_pflen = 24
+
+        self.ndk5 = NetdevKeeper(self.onboarding_task2)
+        self.ndk5.hostname = "device5"
+        self.ndk5.vendor = "juniper"
+        self.ndk5.model = "srx300-sys-jb"
+        self.ndk5.serial_number = "123456"
+        self.ndk5.mgmt_ifname = "ge-0/0/0"
+        self.ndk5.mgmt_pflen = 24
+
     def test_ensure_device_type_missing(self):
         """Verify ensure_device_type function when Manufacturer and DeviceType object are not present."""
         nbk = NetboxKeeper(self.ndk1)
@@ -104,41 +128,17 @@ class NetboxKeeperTestCase(TestCase):
         self.assertEqual(nbk.device_type, self.device_type1)
 
         # Case2: the model is lower case where the existing devicetype slug is in Uppercase
-        self.ndk3 = NetdevKeeper(self.onboarding_task2)
-        self.ndk3.hostname = "device3"
-        self.ndk3.vendor = "juniper"
-        self.ndk3.model = "srx300"
-        self.ndk3.serial_number = "123456"
-        self.ndk3.mgmt_ifname = "ge-0/0/0"
-        self.ndk3.mgmt_pflen = 24
-
         nbk = NetboxKeeper(self.ndk3)
         nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
         self.assertEqual(nbk.manufacturer, self.manufacturer1)
         self.assertEqual(nbk.device_type, self.device_type2)
 
         # Case3: the device model match the model of an existing device_type, not the slug
-        self.ndk4 = NetdevKeeper(self.onboarding_task2)
-        self.ndk4.hostname = "device4"
-        self.ndk4.vendor = "juniper"
-        self.ndk4.model = "srx 300"
-        self.ndk4.serial_number = "123456"
-        self.ndk4.mgmt_ifname = "ge-0/0/0"
-        self.ndk4.mgmt_pflen = 24
-
         nbk = NetboxKeeper(self.ndk4)
         nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
         self.assertEqual(nbk.device_type, self.device_type2)
 
         # Case4: the device model match the part number of an existing device_type, not the slug
-        self.ndk5 = NetdevKeeper(self.onboarding_task2)
-        self.ndk5.hostname = "device5"
-        self.ndk5.vendor = "juniper"
-        self.ndk5.model = "srx300-sys-jb"
-        self.ndk5.serial_number = "123456"
-        self.ndk5.mgmt_ifname = "ge-0/0/0"
-        self.ndk5.mgmt_pflen = 24
-
         nbk = NetboxKeeper(self.ndk5)
         nbk.ensure_device_type(create_manufacturer=False, create_device_type=False)
         self.assertEqual(nbk.device_type, self.device_type2)


### PR DESCRIPTION
Fixes #52

- Update the search query for existing Device, DeviceType and DeviceRole to be case insensitive 
- For DeviceType, search for a match on Model and Part Number as well as slug