### PR TITLE
Enable metrics for workers

### DIFF
--- a/netbox_onboarding/metrics.py
+++ b/netbox_onboarding/metrics.py
@@ -1,0 +1,18 @@
+"""Plugin additions to the NetBox navigation menu.
+
+(c) 2020 Network To Code
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from prometheus_client import Counter
+
+onboardingtask_results_counter = Counter(
+    name="onboardingtask_results_total", documentation="Count of results for Onboarding Task", labelnames=("status",)
+)


### PR DESCRIPTION
This pull request aims to add two metrics for the Onboarding Task process at the worker level:
- Summary of the onboarding processing time,
- Counter for the results.

Both metrics are exposed at the worker level - they are worker-specific instead of model/database bounded. By implementing these metrics, it is possible to get brief information related to worker's performance and potential connectivity issues

```
# HELP onboargingtask_results_total Multiprocess metric
# TYPE onboargingtask_results_total counter
onboargingtask_results_total{status="failed"} 4.0
# HELP onboardingtask_processing_seconds Multiprocess metric
# TYPE onboardingtask_processing_seconds summary
onboardingtask_processing_seconds_count 1.0
onboardingtask_processing_seconds_sum 30.05478549201507
```