### PR TITLE
Fixes onboarding_extensions_map issue

### DIFF
--- a/development/base_configuration.py
+++ b/development/base_configuration.py
@@ -114,7 +114,20 @@ ENFORCE_GLOBAL_UNIQUE = False
 
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/1.11/topics/logging/
-LOGGING = {}
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"rq_console": {"format": "%(asctime)s %(message)s", "datefmt": "%H:%M:%S",},},
+    "handlers": {
+        "rq_console": {
+            "level": "DEBUG",
+            "class": "rq.utils.ColorizingStreamHandler",
+            "formatter": "rq_console",
+            "exclude": ["%(asctime)s"],
+        },
+    },
+    "loggers": {"rq.worker": {"handlers": ["rq_console"], "level": "DEBUG"},},
+}
 
 # Setting this to True will permit only authenticated users to access any part of NetBox. By default, anonymous users
 # are permitted to access most data in NetBox (excluding secrets) but not make any changes.

--- a/netbox_onboarding/netdev_keeper.py
+++ b/netbox_onboarding/netdev_keeper.py
@@ -32,6 +32,9 @@ from netbox_onboarding.onboarding.onboarding import StandaloneOnboarding
 from .constants import NETMIKO_TO_NAPALM_STATIC
 from .exceptions import OnboardException
 
+logger = logging.getLogger("rq.worker")
+logger.setLevel(logging.DEBUG)
+
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["netbox_onboarding"]
 
 
@@ -144,7 +147,7 @@ class NetdevKeeper:
           OnboardException('fail-connect'):
             When device unreachable
         """
-        logging.info("CHECK: IP %s:%s", self.hostname, self.port)
+        logger.info("CHECK: IP %s:%s", self.hostname, self.port)
 
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -169,24 +172,24 @@ class NetdevKeeper:
         }
 
         try:
-            logging.info("INFO guessing device type: %s", self.hostname)
+            logger.info("INFO guessing device type: %s", self.hostname)
             guesser = SSHDetect(**remote_device)
             guessed_device_type = guesser.autodetect()
-            logging.info("INFO guessed device type: %s", guessed_device_type)
+            logger.info("INFO guessed device type: %s", guessed_device_type)
 
         except NetMikoAuthenticationException as err:
-            logging.error("ERROR %s", err)
+            logger.error("ERROR %s", err)
             raise OnboardException(reason="fail-login", message=f"ERROR: {str(err)}")
 
         except (NetMikoTimeoutException, SSHException) as err:
-            logging.error("ERROR: %s", str(err))
+            logger.error("ERROR: %s", str(err))
             raise OnboardException(reason="fail-connect", message=f"ERROR: {str(err)}")
 
         except Exception as err:
-            logging.error("ERROR: %s", str(err))
+            logger.error("ERROR: %s", str(err))
             raise OnboardException(reason="fail-general", message=f"ERROR: {str(err)}")
 
-        logging.info("INFO device type is: %s", guessed_device_type)
+        logger.info("INFO device type is: %s", guessed_device_type)
 
         return guessed_device_type
 
@@ -194,7 +197,7 @@ class NetdevKeeper:
         """Sets napalm driver name."""
         if not self.napalm_driver:
             netmiko_device_type = self.guess_netmiko_device_type()
-            logging.info("Guessed Netmiko Device Type: %s", netmiko_device_type)
+            logger.info("Guessed Netmiko Device Type: %s", netmiko_device_type)
 
             self.netmiko_device_type = netmiko_device_type
 
@@ -234,7 +237,7 @@ class NetdevKeeper:
 
         self.check_reachability()
 
-        logging.info("COLLECT: device information %s", self.hostname)
+        logger.info("COLLECT: device information %s", self.hostname)
 
         try:
             # Get Napalm Driver with Netmiko if needed
@@ -257,10 +260,10 @@ class NetdevKeeper:
 
             napalm_device.open()
 
-            logging.info("COLLECT: device facts")
+            logger.info("COLLECT: device facts")
             self.facts = napalm_device.get_facts()
 
-            logging.info("COLLECT: device interface IPs")
+            logger.info("COLLECT: device interface IPs")
             self.ip_ifs = napalm_device.get_interfaces_ip()
 
             try:
@@ -270,7 +273,7 @@ class NetdevKeeper:
                 self.onboarding_class = driver_addon_class.onboarding_class
                 self.driver_addon_result = driver_addon_class.ext_result
             except ImportError as exc:
-                logging.info("No onboarding extension found for driver %s", self.napalm_driver)
+                logger.info("No onboarding extension found for driver %s", self.napalm_driver)
 
         except ConnectionException as exc:
             raise OnboardException(reason="fail-login", message=exc.args[0])

--- a/netbox_onboarding/netdev_keeper.py
+++ b/netbox_onboarding/netdev_keeper.py
@@ -268,10 +268,11 @@ class NetdevKeeper:
 
             try:
                 module_name = PLUGIN_SETTINGS["onboarding_extensions_map"].get(self.napalm_driver)
-                module = importlib.import_module(module_name)
-                driver_addon_class = module.OnboardingDriverExtensions(napalm_device=napalm_device)
-                self.onboarding_class = driver_addon_class.onboarding_class
-                self.driver_addon_result = driver_addon_class.ext_result
+                if module_name:
+                    module = importlib.import_module(module_name)
+                    driver_addon_class = module.OnboardingDriverExtensions(napalm_device=napalm_device)
+                    self.onboarding_class = driver_addon_class.onboarding_class
+                    self.driver_addon_result = driver_addon_class.ext_result
             except ImportError as exc:
                 logger.info("No onboarding extension found for driver %s", self.napalm_driver)
 

--- a/netbox_onboarding/template_content.py
+++ b/netbox_onboarding/template_content.py
@@ -25,8 +25,11 @@ class DeviceContent(PluginTemplateExtension):  # pylint: disable=abstract-method
         """Show table on right side of view."""
         onboarding = OnboardingDevice.objects.filter(device=self.context["object"]).first()
 
+        if not onboarding:
+            return ""
+
         if not onboarding.enabled:
-            return None
+            return ""
 
         status = onboarding.status
         last_check_attempt_date = onboarding.last_check_attempt_date

--- a/netbox_onboarding/template_content.py
+++ b/netbox_onboarding/template_content.py
@@ -25,10 +25,7 @@ class DeviceContent(PluginTemplateExtension):  # pylint: disable=abstract-method
         """Show table on right side of view."""
         onboarding = OnboardingDevice.objects.filter(device=self.context["object"]).first()
 
-        if not onboarding:
-            return ""
-
-        if not onboarding.enabled:
+        if not onboarding or not onboarding.enabled:
             return ""
 
         status = onboarding.status

--- a/netbox_onboarding/views.py
+++ b/netbox_onboarding/views.py
@@ -25,8 +25,7 @@ from .forms import OnboardingTaskForm, OnboardingTaskFilterForm, OnboardingTaskF
 from .models import OnboardingTask
 from .tables import OnboardingTaskTable, OnboardingTaskFeedBulkTable
 
-log = logging.getLogger("rq.worker")
-log.setLevel(logging.DEBUG)
+logger = logging.getLogger("rq.worker")
 
 
 if NETBOX_RELEASE_CURRENT < NETBOX_RELEASE_29:

--- a/netbox_onboarding/worker.py
+++ b/netbox_onboarding/worker.py
@@ -26,7 +26,6 @@ from .models import OnboardingTask
 from .onboard import OnboardingManager
 
 logger = logging.getLogger("rq.worker")
-logger.setLevel(logging.DEBUG)
 
 
 @job("default")
@@ -80,7 +79,7 @@ def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
         if onboarded_device:
             ot.created_device = onboarded_device
 
-        logger.error("Onboarding Error - OnboardException")
+        logger.error("%s", exc)
         ot.status = OnboardingStatusChoices.STATUS_FAILED
         ot.failed_reason = exc.reason
         ot.message = exc.message


### PR DESCRIPTION
This PR addresses the following issues:

- The onboarding_extensions_map setting (specified in netbox_onboarding/__init__.py
or overridden in configuration.py) is used to map napalm driver names to a custom
class which extends the driver, allowing extensibility. Currently, when a mapping
doesn't exist for a napalm driver, the NetdevKeepr class's get_onboarding_facts()
method fails. This causes the rq-worker to be unable to run the onboard_device()
function to onboard a device. The changes in this commit fix the issue.

- Logging is not instantiated in the same way from file to file, and thus log messages
don't come through (at all in some cases) or consistently (in others). This PR standardizes
logging such that logs are consistently displayed while troubleshooting

- Currently, the template_content.py DeviceContent class returns `None` if onboarding is 
not enabled for an OnboardingDevice object. Likewise, if no OnboardingDevice object 
exists, the template continues trying to access attributes for an OnboardingDevice object. 
In the first case, template rendering will fail as an empty string is needed in order to insert 
nothing into the rendered HTML template presented to the user. In the second case, an 
AttributeError is raised as you can not access attributes of a NoneType object. This PR returns
empty strings in both cases to ensure the HTML renders correctly.
