### PR TITLE
Add NetBox's changelog model to OnboardingTask

### DIFF
--- a/netbox_onboarding/admin.py
+++ b/netbox_onboarding/admin.py
@@ -32,5 +32,5 @@ class OnboardingTaskAdmin(admin.ModelAdmin):
         "failed_reason",
         "port",
         "timeout",
-        "created_on",
+        "created",
     )

--- a/netbox_onboarding/migrations/0003_onboardingtask_change_logging_model.py
+++ b/netbox_onboarding/migrations/0003_onboardingtask_change_logging_model.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_onboarding", "0002_onboardingdevice"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="onboardingtask", name="created", field=models.DateField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="onboardingtask", name="last_updated", field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AlterModelOptions(name="onboardingtask", options={},),
+        migrations.RemoveField(model_name="onboardingtask", name="created_on",),
+    ]

--- a/netbox_onboarding/tables.py
+++ b/netbox_onboarding/tables.py
@@ -30,7 +30,7 @@ class OnboardingTaskTable(BaseTable):
         fields = (
             "pk",
             "id",
-            "created_on",
+            "created",
             "ip_address",
             "site",
             "platform",
@@ -50,7 +50,7 @@ class OnboardingTaskFeedBulkTable(BaseTable):
         model = OnboardingTask
         fields = (
             "id",
-            "created_on",
+            "created",
             "site",
             "platform",
             "ip_address",

--- a/netbox_onboarding/template_content.py
+++ b/netbox_onboarding/template_content.py
@@ -25,8 +25,8 @@ class DeviceContent(PluginTemplateExtension):  # pylint: disable=abstract-method
         """Show table on right side of view."""
         onboarding = OnboardingDevice.objects.filter(device=self.context["object"]).first()
 
-        if not onboarding.enabled:
-            return None
+        if not onboarding or not onboarding.enabled:
+            return ""
 
         status = onboarding.status
         last_check_attempt_date = onboarding.last_check_attempt_date

--- a/netbox_onboarding/templates/netbox_onboarding/onboardingtask.html
+++ b/netbox_onboarding/templates/netbox_onboarding/onboardingtask.html
@@ -18,6 +18,11 @@
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>
             <a href="{{ onboardingtask.get_absolute_url }}">Onboarding Task</a>
         </li>
+        {% if perms.extras.view_objectchange %}
+            <li role="presentation"{% if active_tab == 'changelog' %} class="active"{% endif %}>
+                <a href="{% url 'plugins:netbox_onboarding:onboardingtask_changelog' pk=onboardingtask.pk %}">Change Log</a>
+            </li>
+        {% endif %}
     </ul>
 {% endblock %}
 
@@ -74,8 +79,8 @@
                     <td>{{ onboardingtask.message|placeholder }}</td>
                 </tr>
                 <tr>
-                    <td>Created On</td>
-                    <td>{{ onboardingtask.created_on|placeholder }}</td>
+                    <td>Created</td>
+                    <td>{{ onboardingtask.created|placeholder }}</td>
                 </tr>
             </table>
         </div>

--- a/netbox_onboarding/urls.py
+++ b/netbox_onboarding/urls.py
@@ -12,7 +12,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from django.urls import path
+from extras.views import ObjectChangeLogView
 
+from .models import OnboardingTask
 from .views import (
     OnboardingTaskView,
     OnboardingTaskListView,
@@ -27,4 +29,10 @@ urlpatterns = [
     path("add/", OnboardingTaskCreateView.as_view(), name="onboardingtask_add"),
     path("delete/", OnboardingTaskBulkDeleteView.as_view(), name="onboardingtask_bulk_delete"),
     path("import/", OnboardingTaskFeedBulkImportView.as_view(), name="onboardingtask_import"),
+    path(
+        "<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="onboardingtask_changelog",
+        kwargs={"model": OnboardingTask},
+    ),
 ]


### PR DESCRIPTION
The goal of this PR is as follows:
- integrate Change Log (NetBox's) to Onboarding Task model,
- replace legacy created_on attribute of OnboardingTask with created from ChangeLoggedModel model,
- display template content's elements using ChangeLoggedModel
- add new view for ChangeLoggedModel of OnboardingTask
- reiterate and fix properties' behaviour in models.py for OnboardedDevice (previous version was likely to fail in multiple scenarios)

With NetBox's ChangeLoggedModel, we can access the onboarding task's creation/modification history including information about the user requesting change