### PR TITLE
Support to skip device type updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The plugin behavior can be controlled with the following list of settings
 - `default_device_role_color` string (default FF0000), color assigned to the device role if it needs to be created.
 - `default_management_interface` string (default "PLACEHOLDER"), name of the management interface that will be created, if one can't be identified on the device.
 - `default_management_prefix_length` integer ( default 0), length of the prefix that will be used for the management IP address, if the IP can't be found.
+- `skip_device_type_on_update` boolean (default False), If True, an existing NetBox device will not get its device type updated. If False, device type will be updated with one discovered on a device.
+- `skip_manufacturer_on_update` boolean (default False), If True, an existing NetBox device will not get its manufacturer updated. If False, manufacturer will be updated with one discovered on a device.
 - `platform_map` (dictionary), mapping of an **auto-detected** Netmiko platform to the **NetBox slug** name of your Platform. The dictionary should be in the format:
     ```python
     {

--- a/netbox_onboarding/__init__.py
+++ b/netbox_onboarding/__init__.py
@@ -39,6 +39,8 @@ class OnboardingConfig(PluginConfig):
         "default_management_prefix_length": 0,
         "default_device_status": "active",
         "create_management_interface_if_missing": True,
+        "skip_device_type_on_update": False,
+        "skip_manufacturer_on_update": False,
         "platform_map": {},
         "onboarding_extensions_map": {"ios": "netbox_onboarding.onboarding_extensions.ios",},
     }


### PR DESCRIPTION
This PR adds a capability of skipping the device type updates for existing NetBox devices in case of re-onboarding process. This is also a re-iteration for the previous MR !74 

New plugin settings : 
* `skip_device_type_on_update`
* `skip_manufacturer_on_update`