### PR TITLE
Changes for multiple criteria searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The plugin behavior can be controlled with the following list of settings
       <Netmiko Platform>: <NetBox Slug> 
     }
     ```
+- `object_match_strategy` (string), defines the method for searching models. There are
+currently two strategies, strict and loose. Strict has to be a direct match, normally 
+using a slug. Loose allows a range of search criteria to match a single object. If multiple
+objects are returned an error is raised. 
 
 ## Usage
 

--- a/netbox_onboarding/__init__.py
+++ b/netbox_onboarding/__init__.py
@@ -41,6 +41,7 @@ class OnboardingConfig(PluginConfig):
         "create_management_interface_if_missing": True,
         "platform_map": {},
         "onboarding_extensions_map": {"ios": "netbox_onboarding.onboarding_extensions.ios",},
+        "object_match_strategy": "loose"
     }
     caching_config = {}
 

--- a/netbox_onboarding/__init__.py
+++ b/netbox_onboarding/__init__.py
@@ -41,7 +41,7 @@ class OnboardingConfig(PluginConfig):
         "create_management_interface_if_missing": True,
         "platform_map": {},
         "onboarding_extensions_map": {"ios": "netbox_onboarding.onboarding_extensions.ios",},
-        "object_match_strategy": "loose"
+        "object_match_strategy": "loose",
     }
     caching_config = {}
 

--- a/netbox_onboarding/netbox_keeper.py
+++ b/netbox_onboarding/netbox_keeper.py
@@ -46,7 +46,7 @@ def object_match(obj, search_array):
         result = obj.objects.get(**search_array[0])
         return result
     except obj.DoesNotExist as error:
-        if PLUGIN_SETTINGS['object_match_strategy'] == "loose":
+        if PLUGIN_SETTINGS["object_match_strategy"] == "loose":
             for search_array_element in search_array[1:]:
                 try:
                     result = obj.objects.get(**search_array_element)
@@ -54,7 +54,10 @@ def object_match(obj, search_array):
                 except obj.DoesNotExist:
                     pass
                 except obj.MultipleObjectsReturned:
-                    raise OnboardException(reason="fail-general", message=f"ERROR multiple objects found in {str(obj)} searching on {str(search_array_element)})")
+                    raise OnboardException(
+                        reason="fail-general",
+                        message=f"ERROR multiple objects found in {str(obj)} searching on {str(search_array_element)})",
+                    )
         raise
 
 
@@ -146,9 +149,7 @@ class NetboxKeeper:
         nb_manufacturer_slug = slugify(self.netdev_vendor)
 
         try:
-            search_array = [
-                {"slug__iexact": nb_manufacturer_slug}
-            ]
+            search_array = [{"slug__iexact": nb_manufacturer_slug}]
             self.nb_manufacturer = object_match(Manufacturer, search_array)
         except Manufacturer.DoesNotExist:
             if create_manufacturer:
@@ -198,7 +199,7 @@ class NetboxKeeper:
             search_array = [
                 {"slug__iexact": nb_device_type_slug},
                 {"model__iexact": self.netdev_model},
-                {"part_number__iexact": self.netdev_model}
+                {"part_number__iexact": self.netdev_model},
             ]
 
             self.nb_device_type = object_match(DeviceType, search_array)

--- a/netbox_onboarding/netbox_keeper.py
+++ b/netbox_onboarding/netbox_keeper.py
@@ -38,7 +38,7 @@ def object_match(obj, search_array):
         return result
     except obj.DoesNotExist:
         if PLUGIN_SETTINGS['object_match_strategy'] == "loose":
-            for search in range(0, len(search_array)):
+            for search in range(1, len(search_array)):
                 try:
                     result = obj.objects.get(**search_array[search])
                     return result

--- a/netbox_onboarding/netbox_keeper.py
+++ b/netbox_onboarding/netbox_keeper.py
@@ -32,20 +32,21 @@ PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["netbox_onboarding"]
 
 def object_match(obj, search_array):
     """Used to search models for multiple criteria.
-        Inputs:
-            obj:            The model used for searching.
-            search_array:   Nested dictionaries used to search models. First criteria will be used
-                            for strict searching. Loose searching will loop through the search_array
-                            until it finds a match. Example below.
-                            [
-                                {"slug__iexact": 'switch1'},
-                                {"model__iexact": 'Cisco'}   
-                            ]
+
+    Inputs:
+        obj:            The model used for searching.
+        search_array:   Nested dictionaries used to search models. First criteria will be used
+                        for strict searching. Loose searching will loop through the search_array
+                        until it finds a match. Example below.
+                        [
+                            {"slug__iexact": 'switch1'},
+                            {"model__iexact": 'Cisco'}
+                        ]
     """
     try:
         result = obj.objects.get(**search_array[0])
         return result
-    except obj.DoesNotExist as error:
+    except obj.DoesNotExist:
         if PLUGIN_SETTINGS["object_match_strategy"] == "loose":
             for search_array_element in search_array[1:]:
                 try:

--- a/netbox_onboarding/netbox_keeper.py
+++ b/netbox_onboarding/netbox_keeper.py
@@ -36,16 +36,18 @@ def object_match(obj, search_array):
     try:
         result = obj.objects.get(**search_array[0])
         return result
-    except obj.DoesNotExist:
+    except obj.DoesNotExist as error:
         if PLUGIN_SETTINGS['object_match_strategy'] == "loose":
-            for search in range(1, len(search_array)):
+            for search_array_element in search_array[1:]:
                 try:
-                    result = obj.objects.get(**search_array[search])
+                    result = obj.objects.get(**search_array_element)
                     return result
                 except obj.DoesNotExist:
                     pass
-        raise obj.DoesNotExist
-                
+                except obj.Multiple:
+                    raise OnboardException(reason="fail-general", message=f"ERROR multiple objects found")
+        raise
+
 
 class NetboxKeeper:
     """Used to manage the information relating to the network device within the NetBox server."""


### PR DESCRIPTION
Draft new function has been created to search multiple criteria for a single model. If the search strategy is set to loose, the function will search in a loop for each criteria. 

Search criteria is pushed into the function, in a nested dictionary. The first item in the array should be the primary search. Example below:

```
def object_match(obj, search_array):
    """Used to search models for multiple criteria."""
    try:
        result = obj.objects.get(**search_array[0])
        return result
    except obj.DoesNotExist as error:
        if PLUGIN_SETTINGS['object_match_strategy'] == "loose":
            for search_array_element in search_array[1:]:
                try:
                    result = obj.objects.get(**search_array_element)
                    return result
                except obj.DoesNotExist:
                    pass
                except obj.Multiple:
                    raise OnboardException(reason="fail-general", message=f"ERROR multiple objects found")
        raise

search_array = [
      {"slug": nb_device_type_slug},
      {"slug__iexact": nb_device_type_slug},
      {"model__iexact": netdev_model},
      {"part_number__iexact": netdev_model}
]
nb_device_type = object_match(DeviceType, search_array)
```