### PR TITLE
Changes for multiple criteria searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The plugin behavior can be controlled with the following list of settings
       <Napalm Driver Name>: <Loadable Python Module>
     }
     ```
+- `object_match_strategy` (string), defines the method for searching models. There are
+currently two strategies, strict and loose. Strict has to be a direct match, normally 
+using a slug. Loose allows a range of search criteria to match a single object. If multiple
+objects are returned an error is raised. 
 
 ## Usage
 

--- a/netbox_onboarding/__init__.py
+++ b/netbox_onboarding/__init__.py
@@ -43,6 +43,7 @@ class OnboardingConfig(PluginConfig):
         "skip_manufacturer_on_update": False,
         "platform_map": {},
         "onboarding_extensions_map": {"ios": "netbox_onboarding.onboarding_extensions.ios",},
+        "object_match_strategy": "loose",
     }
     caching_config = {}
 


### PR DESCRIPTION
REPLACES MR #98  


Draft new function has been created to search multiple criteria for a single model. If the search strategy is set to loose, the function will search in a loop for each criteria.

Search criteria is pushed into the function, in a nested dictionary. The first item in the array should be the primary search. Example below:
```
def object_match(obj, search_array):
    """Used to search models for multiple criteria."""
    try:
        result = obj.objects.get(**search_array[0])
        return result
    except obj.DoesNotExist as error:
        if PLUGIN_SETTINGS['object_match_strategy'] == "loose":
            for search_array_element in search_array[1:]:
                try:
                    result = obj.objects.get(**search_array_element)
                    return result
                except obj.DoesNotExist:
                    pass
                except obj.Multiple:
                    raise OnboardException(reason="fail-general", message=f"ERROR multiple objects found")
        raise

search_array = [
      {"slug": nb_device_type_slug},
      {"slug__iexact": nb_device_type_slug},
      {"model__iexact": netdev_model},
      {"part_number__iexact": netdev_model}
]
nb_device_type = object_match(DeviceType, search_array)
```