### PR TITLE
Adds doc to run migrations after updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,7 @@ objects are returned an error is raised.
 
 ## Upgrades
 
-When a new release comes out it is best practice to initiated a migration of the database to account
-for any new migrations that may be needed to the DB. Execute a `python manage.py migrate`from the
-NetBox install `netbox/` directory.  
+When a new release comes out it may be necessary to run a migration of the database to account for any changes in the data models used by this plugin. Execute the command `python3 manage.py migrate`from the NetBox install `netbox/` directory after updating the package.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ currently two strategies, strict and loose. Strict has to be a direct match, nor
 using a slug. Loose allows a range of search criteria to match a single object. If multiple
 objects are returned an error is raised. 
 
+## Upgrades
+
+When a new release comes out it is best practice to initiated a migration of the database to account
+for any new migrations that may be needed to the DB. Execute a `python manage.py migrate`from the
+NetBox install `netbox/` directory.  
+
 ## Usage
 
 ### Preparation


### PR DESCRIPTION
When completing the upgrade process I noticed that the application starts to take errors if no migrations are done. This may become a general function of plugins in general. It does not hurt to run migrations after each upgrade even if there are no new migrations to be run. Perhaps this would be a note on releases instead in case there are releases in which the DB schema is not updated.