### PR TITLE
Update travis file to publish release as expected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ deploy:
   on:
     tags: true
     branch: master
-    condition: $NETBOX_VER = master
+    condition: $NETBOX_VER = v2.9.11
     python: 3.7


### PR DESCRIPTION
I noticed that travis didn't published the latest release automatically to pypi because the travis file was referencing `master` instead of a specific netbox version
This is a quick patch to fix that until we refactor the travis file with stages.