### PR TITLE
NetdevKeeper fixes

### DIFF
--- a/netbox_onboarding/netdev_keeper.py
+++ b/netbox_onboarding/netdev_keeper.py
@@ -226,7 +226,11 @@ class NetdevKeeper:
 
             driver = get_network_driver(self.napalm_driver)
 
-            optional_args = self.optional_args.copy()
+            if self.optional_args:
+                optional_args = self.optional_args.copy()
+            else:
+                optional_args = {}
+
             if self.port:
                 optional_args["port"] = self.port
 
@@ -264,6 +268,10 @@ class NetdevKeeper:
                     )
                 except ImportError as exc:
                     raise OnboardException(reason="fail-general", message="ERROR: ImportError: %s" % exc.args[0])
+            elif module_name and not self.load_driver_extension:
+                logger.info(
+                    "INFO: Not loading driver extension"
+                )
             else:
                 logger.info(
                     "INFO: No onboarding extension defined for napalm driver %s, using default napalm driver",


### PR DESCRIPTION
1. In NetdevKeeper, checking if optional_args is None before copying
2. In NetdevKeeper, added a new condition to check if load_driver_extension is not set, and added a log statement accordingly