### PR TITLE
Improve logging for loading driver extensions

### DIFF
--- a/netbox_onboarding/netdev_keeper.py
+++ b/netbox_onboarding/netdev_keeper.py
@@ -274,6 +274,8 @@ class NetdevKeeper:
                     )
                 except ImportError as exc:
                     raise OnboardException(reason="fail-general", message="ERROR: ImportError: %s" % exc.args[0])
+            elif module_name and not self.load_driver_extension:
+                logger.info("INFO: Skipping execution of driver extension")
             else:
                 logger.info(
                     "INFO: No onboarding extension defined for napalm driver %s, using default napalm driver",


### PR DESCRIPTION
This PR adds a new logging message for cases where the plugin detects an existing driver extension, but `load_driver_extension` was explicitly set to skip via class attribute. 

Replaces #124 reported by @dankot12 