### PR TITLE
Fix Issue #93

### DIFF
--- a/netbox_onboarding/migrations/0004_create_onboardingdevice.py
+++ b/netbox_onboarding/migrations/0004_create_onboardingdevice.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def create_missing_onboardingdevice(apps, schema_editor):
+    Device = apps.get_model("dcim", "Device")
+    OnboardingDevice = apps.get_model("netbox_onboarding", "OnboardingDevice")
+
+    for device in Device.objects.filter(onboardingdevice__isnull=True):
+        OnboardingDevice.objects.create(device=device)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_onboarding", "0003_onboardingtask_change_logging_model"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_missing_onboardingdevice),
+    ]

--- a/netbox_onboarding/worker.py
+++ b/netbox_onboarding/worker.py
@@ -36,7 +36,7 @@ REQUEST_TIME = Summary("onboardingtask_processing_seconds", "Time spent processi
 
 @REQUEST_TIME.time()
 @job("default")
-def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
+def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements, too-many-branches
     """Process a single OnboardingTask instance."""
     username = credentials.username
     password = credentials.password
@@ -107,6 +107,10 @@ def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
         ot.message = str(exc)
         ot.save()
         onboarding_status = False
+
+    finally:
+        if onboarded_device and not OnboardingDevice.objects.filter(device=onboarded_device):
+            OnboardingDevice.objects.create(device=onboarded_device)
 
     onboardingtask_results_counter.labels(status=ot.status).inc()
 


### PR DESCRIPTION
This PR fixes issue #93 

OnboardingDevice model instances are created as a part of onboarding process for devices created before ntc-netbox-plugin-onboarding installation. With the fix, template_content is rendered properly for re-onboarded devices.

---
Closes #93 