### PR TITLE
Travis and documentation update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ python:
 env:
 # Each version of NetBox listed here uses configuration stored in development/configuration.py
   matrix:
-  - NETBOX_VER=v2.8.9
   - NETBOX_VER=v2.9.11
-  - NETBOX_VER=v2.10.2
+  - NETBOX_VER=v2.10.10
+  - NETBOX_VER=v2.11.10
 # Encrypted value for PYPI_TOKEN, this secret has been generated with the following command
 #   travis encrypt PYPI_TOKEN=<value> --add env.global --com
 # Might need to update it once the repo is publish (travis-ci.org vs travis-ci.com)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ systemctl restart netbox netbox-rq
 
 ### Compatibility Matrix
 
-|                       | Netbox 2.8 | Netbox 2.9 | Netbox 2.10 |
-|-----------------------|------------|------------|-------------|
-| Onboarding Plugin 1.3 |      X     |            |             |
-| Onboarding Plugin 2.0 |      X     |      X     |             |
-| Onboarding Plugin 2.1 |      X     |      X     |      X      |
+|                       | Netbox 2.8 | Netbox 2.9 | Netbox 2.10 | Netbox 2.11 |
+|-----------------------|------------|------------|-------------|-------------|
+| Onboarding Plugin 1.3 |      X     |            |             |             |
+| Onboarding Plugin 2.0 |      X     |      X     |             |             |
+| Onboarding Plugin 2.1 |      X     |      X     |      X      |      X      |
 
 To ensure NetBox Onboarding plugin is automatically re-installed during future upgrades, create a file named `local_requirements.txt` (if not already existing) in the NetBox root directory (alongside `requirements.txt`) and list the `ntc-netbox-plugin-onboarding` package:
 


### PR DESCRIPTION
- Update in the docs for Netbox release 2.11
- Travis file update - deprecating build for Netbox 2.8, introducing build for Netbox 2.11